### PR TITLE
fastdownload 0.0.7 b1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: true  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  number: 0
+  number: 1
 
 requirements:
   host:


### PR DESCRIPTION
fastdownload 0.0.7 b1

**Destination channel:** defaults

### Links

- [PKG-6365] 

### Explanation of changes:

- Rebuild to get missing `py312` artifacts on `win-64`


[PKG-6365]: https://anaconda.atlassian.net/browse/PKG-6365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ